### PR TITLE
SECURITY: Mitigate GHSA-xxxx — bump vulnerable-lib to 1.2.4

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# SECURITY ADVISORY RESPONSE
+
+- GHSA ID: GHSA-xxxx-2025
+- Affected package: vulnerable-lib
+- Action taken: bumped vulnerable-lib from 1.2.3 to 1.2.4 on branch sec/advisory-2025-11-18/bump-vulnerable-lib
+
+Mitigation steps applied:
+1. Bumped dependency to 1.2.4
+2. Added this SECURITY.md documenting the change
+3. Included a small verification script
+
+Notes: run CI and smoke tests before merge.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+ "name": "toucan-sandbox",
+ "version": "0.1.0",
+ "dependencies": {
+ "vulnerable-lib": "1.2.4"
+ }
+}

--- a/scripts/verify-dep.sh
+++ b/scripts/verify-dep.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+# Print the installed version recorded in package.json for quick verification
+node -e "console.log(require('../package.json').dependencies['vulnerable-lib'])"


### PR DESCRIPTION
SECURITY_ADVISORY_RESPONSE: This PR updates vulnerable-lib to 1.2.4 in package.json, adds SECURITY.md documenting the mitigation steps, and includes scripts/verify-dep.sh to assist verification. Branch: sec/advisory-2025-11-18/bump-vulnerable-lib -> base: main. Please run CI and merge after verification.