### PR TITLE
DOCS: Add French & Spanish README translations (DOCS_LOCALIZATION)

### DIFF
--- a/docs/LOCALIZATION_CHECKLIST.md
+++ b/docs/LOCALIZATION_CHECKLIST.md
@@ -1,0 +1,14 @@
+# Localization Checklist — FR & ES (generated 2025-11-18)
+
+This checklist documents the changes included in branch i18n/docs-sync/fr-es-2025-11-18.
+
+- Languages added: fr, es
+- Files added:
+ - docs/README.fr.md
+ - docs/README.es.md
+- Base branch targeted: main
+- Reason: Provide initial README translations for French and Spanish as part of DOCS_LOCALIZATION sprint.
+
+Notes for reviewers:
+- Verify encoding and formatting for markdown rendering.
+- Confirm the translations are intentionally minimal placeholder translations for sync/testing; this PR does not aim to be complete localization.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,12 @@
+# Toucan Sandbox — Documentación (Español)
+
+Bienvenido a la documentación del proyecto Toucan Sandbox. Esta es una traducción al español del README principal para propósitos de localización.
+
+## Resumen
+Toucan Sandbox es un repositorio de ejemplo usado para demostrar flujos de trabajo de CI/CD y localización.
+
+## Instalación
+1. Clonar el repositorio
+2. Instalar dependencias
+
+(Contenido traducido para pruebas de localización.)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -1,0 +1,12 @@
+# Toucan Sandbox — Documentation (Français)
+
+Bienvenue dans la documentation du projet Toucan Sandbox. Ceci est une traduction française de la page README principale pour les besoins de localisation.
+
+## Aperçu
+Toucan Sandbox est un dépôt d'exemple utilisé pour démontrer des workflows de CI/CD et de localisation.
+
+## Installation
+1. Cloner le dépôt
+2. Installer les dépendances
+
+(Contenu traduit à des fins de test de localisations.)


### PR DESCRIPTION
This PR adds initial French and Spanish translations of the repository README under docs/ and includes a localization checklist. Scenario: DOCS_LOCALIZATION. Reviewer checklist: validate markdown rendering, confirm these are placeholder translations for sync-testing, and suggest further translation improvements.