### PR TITLE
[DOCS_LOCALIZATION] Add French localized docs fragment (2025-11-18)

### DIFF
--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,0 +1,11 @@
+# Documentation Locale — Français
+
+Bienvenue dans la documentation localisée en français pour le dépôt toucan-sandbox. Cette version vise à synchroniser les sections de la documentation qui ont changé sur la branche main au 2025-11-18.
+
+Contenu inclus:
+
+- Aperçu du projet et objectifs (Résumé en français)
+- Étapes d'installation rapides (français)
+- Liens vers les pages principales (to be kept in sync with main)
+
+Veuillez vérifier que cette traduction couvre uniquement le texte de présentation et le guide d'installation rapide — les sections techniques détaillées resteront en anglais jusqu'à ce que la revue de localisation soit terminée.


### PR DESCRIPTION
This PR adds an initial French localized README fragment under docs/fr/README.md to begin DOCS_LOCALIZATION work. Checklist:
- [ ] Confirm that only presentation and quickstart text were translated
- [ ] Run link/format checks on the new file in CI
- [ ] Assign a French-speaking reviewer for linguistic QA

Note: This PR is intentionally small and only covers the top-level README fragment to simplify review. Please do not squash other ongoing localization branches into this one.