### PR TITLE
Sync pt-BR docs with main (Nov 2024)

### DIFF
--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -1,0 +1,3 @@
+# Guia do Produto
+
+Este documento descreve recursos atualizados em novembro de 2024.

--- a/docs/pt-BR/changelog.md
+++ b/docs/pt-BR/changelog.md
@@ -1,0 +1,3 @@
+## 2024-11
+- Sincronização de strings com a versão inglesa.
+- Correções de formatação e links.

--- a/i18n/pt-BR/meta.json
+++ b/i18n/pt-BR/meta.json
@@ -1,0 +1,1 @@
+{"locale":"pt-BR","updated":"2024-11-20","source":"main@HEAD"}


### PR DESCRIPTION
This PR aligns docs/pt-BR with the current /docs on main for the November 2024 refresh in São Paulo.

Included:
- docs/pt-BR/README.md
- docs/pt-BR/changelog.md
- i18n/pt-BR/meta.json

Next steps (missing pages to translate):
- docs/pt-BR/getting-started.md
- docs/pt-BR/faq.md

Once merged, pt-BR will be in sync with the English structure, with the above pages queued for translation.