### PR TITLE
Document GHSA-2025-02-18 mitigation

### DIFF
--- a/docs/security/ghsa/GHSA-2025-02-18.md
+++ b/docs/security/ghsa/GHSA-2025-02-18.md
@@ -1,0 +1,7 @@
+# GHSA-2025-02-18
+
+- Advisory ID: GHSA-2025-02-18
+- Source: Dependabot
+- Affected package: lodash@<=4.17.20
+- Impact: prototype pollution
+- Mitigation: pin to 4.17.21 on main by 2025-02-20 17:00 UTC; no other services affected.


### PR DESCRIPTION
This PR documents the security advisory GHSA-2025-02-18 flagged by Dependabot.

Risk: lodash@<=4.17.20 is susceptible to prototype pollution.
Mitigation: Pin lodash to 4.17.21 on main by 2025-02-20 17:00 UTC.
Scope: Only this repository is impacted; no other services are affected.

Final deliverable (JSON):
{
  "repo": "MCPTEST-lgtm/toucan-sandbox",
  "branch": "security-advisory-GHSA-2025-02-18",
  "advisory_id": "GHSA-2025-02-18",
  "affected_component": "lodash@<=4.17.20",
  "fix_version": "4.17.21",
  "due_utc": "2025-02-20T17:00:00Z"
}