### PR TITLE
Merge Queue Snapshot — London 2025-11-21

### DIFF
--- a/reports/queue_summary.json
+++ b/reports/queue_summary.json
@@ -1,0 +1,12 @@
+[
+  {"number":14, "title":"Add CONTRIBUTING.md and link from README", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":17, "title":"docs: add SECURITY_CREDENTIALS.md — credential storage and rotation guidance", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":34, "title":"SECURITY: Mitigate GHSA-xxxx — bump vulnerable-lib to 1.2.4", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":35, "title":"HOTFIX_RELEASE: critical config patch and CI validation (hotfix/2025-11-18-critical-config)", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":36, "title":"DOCS: Add French & Spanish README translations (DOCS_LOCALIZATION)", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":37, "title":"DEPLOYMENT_BLOCKER: set DEPLOY_ENV in CI deploy workflow", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":38, "title":"HOTFIX: SECURITY.md emergency mitigation note (2025-11-18)", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":39, "title":"MERGE_QUEUE_TRIAGE: Add triage policy and initial 2025-11-18 report", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":40, "title":"DOC: Document resolution for deployment blocker #101", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3},
+  {"number":41, "title":"[DOCS_LOCALIZATION] Add French localized docs fragment (2025-11-18)", "author":"MCPTEST-lgtm", "reviewers":[], "ci_status":"unknown", "days_waiting":3}
+]

--- a/reports/queue_summary.md
+++ b/reports/queue_summary.md
@@ -1,0 +1,35 @@
+Merge Queue Snapshot — London 2025-11-21
+
+Summary
+- Source: MCPTEST-lgtm/toucan-sandbox, open pull requests as of 2025-11-21 (London)
+- Scope: Top 10 PRs by waiting time (oldest first)
+- Ranking heuristic (unblock effort):
+  1) Days waiting (higher first)
+  2) CI status (fail > pending/unknown > success for unblock effort)
+  3) Reviewer load (more requested reviewers lowers effort if already assigned; none assigned increases coordination needed)
+  4) Deterministic tie-break: PR number ascending
+
+Observations today
+- All top 10 items have been waiting ~3 days (opened on 2025-11-18 UTC).
+- No requested reviewers are recorded on these PRs; coordination may be the primary blocker.
+- CI status was not available from the snapshot context, so treated as "unknown" for ranking (tie-break by PR number).
+
+Actions to unblock quickly
+- Assign reviewers for SECURITY and HOTFIX-labelled PRs first (e.g., #34, #35, #38, #39).
+- Nudge authors to trigger CI where status is unknown.
+- Consider batched review for docs-only changes (#36, #41) to reduce reviewer context switching.
+
+Top 10 (ranked)
+1) #14 — Add CONTRIBUTING.md and link from README — 3 days waiting — CI: unknown — reviewers: none
+2) #17 — docs: add SECURITY_CREDENTIALS.md — 3 days waiting — CI: unknown — reviewers: none
+3) #34 — SECURITY: Mitigate GHSA-xxxx — bump vulnerable-lib to 1.2.4 — 3 days waiting — CI: unknown — reviewers: none
+4) #35 — HOTFIX_RELEASE: critical config patch and CI validation — 3 days waiting — CI: unknown — reviewers: none
+5) #36 — DOCS: Add French & Spanish README translations — 3 days waiting — CI: unknown — reviewers: none
+6) #37 — DEPLOYMENT_BLOCKER: set DEPLOY_ENV in CI deploy workflow — 3 days waiting — CI: unknown — reviewers: none
+7) #38 — HOTFIX: SECURITY.md emergency mitigation note — 3 days waiting — CI: unknown — reviewers: none
+8) #39 — MERGE_QUEUE_TRIAGE: Add triage policy and initial report — 3 days waiting — CI: unknown — reviewers: none
+9) #40 — DOC: Document resolution for deployment blocker #101 — 3 days waiting — CI: unknown — reviewers: none
+10) #41 — [DOCS_LOCALIZATION] Add French localized docs fragment — 3 days waiting — CI: unknown — reviewers: none
+
+Notes
+- With CI and reviewer signals missing, prioritization defaults to age; once CI and reviewer data populate, ranking will automatically emphasize items with passing CI and already-assigned reviewers (lower unblock effort).


### PR DESCRIPTION
This daily leadership snapshot compiles the London merge queue as of 2025-11-21 and delivers two artifacts:

- reports/queue_summary.md — a concise narrative for the top 10 PRs by waiting time, with observations and recommended unblock actions.
- reports/queue_summary.json — a deterministic array of items with {number, title, author, reviewers[], ci_status, days_waiting}.

Ranking method (unblock effort):
- Prioritize by days waiting (older first), then penalize failing CI over pending/unknown over success (i.e., items that need CI or are failing bubble up to the top for attention), then factor reviewer load (PRs already with assigned reviewers are cheaper to unblock than those needing assignment). Ties break deterministically by PR number.

Notes on this snapshot:
- Requested reviewers were not available from the snapshot context, so reviewers[] is empty for all items.
- CI status was not available for the listed PR SHAs via this interface; items default to ci_status="unknown". This preserves determinism while signaling where CI reruns or check re-fetching may be required.

Deliverables are included in this PR for immediate review and consumption.