### PR TITLE
Daily Merge Queue Snapshot — 2025-11-21

### DIFF
--- a/docs/ops/merge-queue-2025-11-21.md
+++ b/docs/ops/merge-queue-2025-11-21.md
@@ -1,0 +1,19 @@
+# Daily Merge Queue Snapshot — 2025-11-21
+
+Time window: PRs updated in the last 24 hours.
+
+Priority scoring notes:
+- Highest priority: PRs touching /services/billing/* or /infra/terraform/*
+- Otherwise: weigh requested reviewers and CI status (failing CI with active reviewers ranks above passing CI with no reviewers)
+
+## Queue Overview
+
+| PR# | Title | Requested reviewers | CI status | Priority |
+| --- | ----- | ------------------- | --------- | -------- |
+
+_No qualifying pull requests were updated in the last 24 hours._
+
+## Risk brief (Engineering Ops — New York)
+- Risk to tomorrow’s standup is low given the quiet queue; no billing or Terraform changes were observed in the last 24 hours.
+- CI signal appears stable with no high-risk sequences identified; continue to monitor early-morning pushes from other time zones.
+- Recommendation for the NY team: prepare fast-review capacity for any late-arriving billing/infra updates and pre-assign reviewers to minimize idle queue time.


### PR DESCRIPTION
This daily report blends reviewer assignments with CI signal to guide sequencing for tomorrow’s standup. It highlights any PRs updated in the last 24 hours, prioritizing changes that touch /services/billing/* and /infra/terraform/*, and consolidates requested reviewers and CI outcomes. Use this snapshot to align review focus and unblock the merge queue efficiently.