### PR TITLE
Onboarding Metrics Report: 2025-11-23

### DIFF
--- a/docs/engagement/onboarding-2025-11-23.json
+++ b/docs/engagement/onboarding-2025-11-23.json
@@ -1,0 +1,12 @@
+{
+  "period_start": "2025-10-24",
+  "period_end": "2025-11-23",
+  "repo": "MCPTEST-lgtm/toucan-sandbox",
+  "summary": {
+    "total_prs_opened_by_first_time_contributors": 0,
+    "avg_time_to_first_review_hours": 0,
+    "avg_comments_per_pr": 0,
+    "percent_prs_requiring_changes": 0
+  },
+  "breakdown_by_contributor": {}
+}


### PR DESCRIPTION
This PR introduces the onboarding metrics report for first-time contributor activity covering 2025-10-24 through 2025-11-23 for MCPTEST-lgtm/toucan-sandbox.

Purpose:
- Help identify bottlenecks in first-response SLAs (time-to-first-review)
- Assess discussion density via comments-per-PR
- Track the percentage of PRs requiring changes before merge

Deliverable:
- docs/engagement/onboarding-2025-11-23.json containing the summarized metrics and contributor-level breakdown.

Note: Initial values are placeholders and can be updated as new data is collected or refined.