### PR TITLE
Dependency Risk Register — 2025‑11‑23

### DIFF
--- a/docs/compliance/deps-audit-2025-11-23.md
+++ b/docs/compliance/deps-audit-2025-11-23.md
@@ -1,0 +1,29 @@
+# Dependency Vulnerability Audit — 2025-11-23
+
+Scope: package.json and requirements.txt. This snapshot intentionally includes only the entries listed below to ensure deterministic content.
+
+## Findings
+
+1) lodash
+- Package manager: npm
+- File: package.json
+- Version in repo: 4.17.15
+- CVE: CVE-2020-28500
+- Fixed target version: 4.17.21
+- Notes: upgrade via `npm install lodash@4.17.21`
+
+2) requests
+- Package manager: pip
+- File: requirements.txt
+- Version in repo: 2.19.1
+- CVE: CVE-2018-18074
+- Fixed target version: 2.31.0
+- Notes: upgrade via `pip install -U "requests==2.31.0"`
+
+## Remediation status and owners
+- lodash (npm): owner dev@toucan — Status: Pending remediation
+- requests (pip): owner sre@toucan — Status: Pending remediation
+
+## Sign-off
+- Security: Pending
+- SRE: Pending


### PR DESCRIPTION
This pull request adds the dependency vulnerability audit snapshot for 2025-11-23.

Scope: package.json and requirements.txt.

Included findings are deterministic and currently limited to:
- lodash 4.17.15 → 4.17.21 (CVE-2020-28500) — owner: dev@toucan
- requests 2.19.1 → 2.31.0 (CVE-2018-18074) — owner: sre@toucan

Please review and sign off:
- Security: confirm CVE coverage and severity assessment
- SRE: confirm upgrade path and rollout plan

Once approved, remediation owners can proceed to create implementation PRs. Thank you.