### PR TITLE
Merge queue triage: November 2025

### DIFF
--- a/reports/merge-queue-2025-11.json
+++ b/reports/merge-queue-2025-11.json
@@ -1,0 +1,14 @@
+[
+  {"number": 120, "title": "Hotfix: Null guard for request handler (2025-11-21)", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 1},
+  {"number": 135, "title": "HOTFIX: Log4j CVE-2025-0001 patch notes", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 2},
+  {"number": 136, "title": "Hotfix: force HTTPS in production", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 3},
+  {"number": 137, "title": "Hotfix: reduce default timeout to 45s (2025-11-21)", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 4},
+  {"number": 138, "title": "GHSA Response: lodash and OpenSSL upgrades (2025-11-21)", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 5},
+  {"number": 218, "title": "Document mitigation for GHSA-2025-0420", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 6},
+  {"number": 197, "title": "Dependency Risk Register — 2025‑11‑23", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 7},
+  {"number": 83, "title": "Merge Queue Triage — 2025-11-20", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 8},
+  {"number": 139, "title": "Daily Merge Queue Snapshot — 2025-11-21", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 9},
+  {"number": 171, "title": "Onboarding metrics pack (Q4 2025)", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 10},
+  {"number": 196, "title": "Onboarding Metrics Report: 2025-11-23", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 11},
+  {"number": 220, "title": "Sync zh-CN docs with upstream (2025-11)", "size_category": "unknown", "requested_reviewers": [], "ci_status": "unknown", "priority_rank": 12}
+]

--- a/reports/merge-queue-2025-11.md
+++ b/reports/merge-queue-2025-11.md
@@ -1,0 +1,35 @@
+Merge queue triage: November 2025 — compact leadership snapshot (NYC)
+
+Scope and method
+- Source: MCPTEST-lgtm/toucan-sandbox open PRs as of 2025-11-24.
+- Prioritization: large PRs (≥500 changed lines) would be ranked first, followed by urgency signals. The current interface does not expose line counts or requested reviewers; no items could be positively tagged as “large” in this snapshot. We therefore fall back to an urgency rubric: Hotfixes → Security/GHSA → Dependency risks → Merge-queue reports → Operational/engagement reports → Docs syncs. Ties are broken deterministically by PR number.
+- CI checks: check statuses are not accessible via this channel at snapshot time; items are marked ci_status=unknown and should be re-polled in GitHub UI before merge sequencing.
+
+Top priorities (aligns with JSON priority_rank)
+1) #120 Hotfix: Null guard for request handler — production mitigation; ensure smoke tests green. Reviewers: none listed here. CI: unknown.
+2) #135 HOTFIX: Log4j CVE-2025-0001 patch notes — audit/documentation for security response. Reviewers: none. CI: unknown.
+3) #136 Hotfix: force HTTPS in production — correct redirect behavior; validate 301s. Reviewers: none. CI: unknown.
+4) #137 Hotfix: reduce default timeout to 45s — rollout safety; validate latency. Reviewers: none. CI: unknown.
+5) #138 GHSA Response: lodash and OpenSSL upgrades — verify npm audit and OpenSSL version. Reviewers: none. CI: unknown.
+6) #218 Document mitigation for GHSA-2025-0420 — finalize advisory docs. Reviewers: none. CI: unknown.
+7) #197 Dependency Risk Register — remediation planning gate; confirm owners. Reviewers: none. CI: unknown.
+8) #83 Merge Queue Triage — historical triage artifact; ensure consistency. Reviewers: none. CI: unknown.
+9) #139 Daily Merge Queue Snapshot — ensure latest signals reflected. Reviewers: none. CI: unknown.
+10) #171 Onboarding metrics pack (Q4 2025) — leadership consumption; not blocking prod. Reviewers: none. CI: unknown.
+11) #196 Onboarding Metrics Report — same as above. Reviewers: none. CI: unknown.
+12) #220 Sync zh-CN docs with upstream — likely larger diff; schedule off-peak review window. Reviewers: none. CI: unknown.
+
+Notes on large PRs (≥500 LOC changed)
+- Large-PR detection is not available in this snapshot; doc sync PRs (#220) are the most likely to cross the threshold. Re-check in the PR “Files changed” tab; if ≥500, keep them high-visibility but land outside peak hours.
+
+Blockers to clear by end of week (EOW)
+- Reviewer assignment: none of the items surfaced requested reviewers via this interface. Action: assign reviewers in GitHub to accelerate TTR.
+- CI signal: all marked unknown here. Action: re-run or fetch checks; ensure green before sequencing. For hotfixes/security (#120, #135–#138), prioritize checks and fast-follow approvals.
+- Cross-repo dependencies: validate that security and hotfix PRs do not depend on other pending changes; otherwise break into smaller merges.
+
+How this narrative aligns with the JSON priorities
+- The JSON file uses the same urgency-first rubric with deterministic tie-breaks and includes ci_status and requested_reviewers fields (both unknown/empty here). The listed priority_rank values 1–12 match the order enumerated above to keep discussion anchored to one sequence.
+
+Next steps
+- Confirm reviewers and CI status on the top 6 (hotfix/security) today.
+- If any doc sync PRs exceed 500 LOC, earmark reviews for tomorrow morning ET with two reviewers to compress cycle time.


### PR DESCRIPTION
This PR adds the November 2025 merge-queue snapshot for leadership (NYC) under reports/:

- reports/merge-queue-2025-11.md — a compact narrative that prioritizes hotfixes and security work first, and calls out likely large PRs (doc syncs) for off-peak review windows. Because line counts and reviewer requests are not exposed in this interface, the narrative explains the fallback prioritization rubric and explicitly instructs to validate size (≥500 LOC), requested reviewers, and CI state in GitHub before merge sequencing.
- reports/merge-queue-2025-11.json — a deterministic array of {number, title, size_category, requested_reviewers, ci_status, priority_rank}. Both requested_reviewers and ci_status are filled with empty/"unknown" placeholders where data was not available via API. The listed priority_rank values 1–12 match the narrative order.

Alignment and blockers:
- Alignment: The narrative order exactly matches the JSON priority_rank to keep standup discussion synchronized.
- Blockers to clear by EOW: (a) assign/confirm reviewers on the top 6 PRs (hotfix/security), (b) fetch or re-run CI to obtain green signal, (c) for any PRs ≥500 LOC (likely doc syncs), schedule two-reviewer slots outside peak hours, and (d) verify no hidden cross-repo dependencies.

Once these are cleared, we can begin sequencing merges from top to bottom, revalidating CI between landings.